### PR TITLE
Inject optimizer via FastAPI dependency

### DIFF
--- a/fastapi_app/main.py
+++ b/fastapi_app/main.py
@@ -1,45 +1,77 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from prompt_optimizer.api import PromptOptimizer
 
 app = FastAPI(title="PromptCraft API")
-optimizer = PromptOptimizer()
+
+# Store the optimizer instance on the application state so tests can
+# override it via dependency injection.
+app.state.optimizer = PromptOptimizer()
+
+
+def get_optimizer() -> PromptOptimizer:
+    """Retrieve the current optimizer instance."""
+    return app.state.optimizer
 
 @app.post("/prompts")
-async def register_prompt(text: str, description: str = ""):
+async def register_prompt(
+    text: str,
+    description: str = "",
+    optimizer: PromptOptimizer = Depends(get_optimizer),
+):
     result = optimizer.register_prompt(text, description)
     return result.model_dump()
 
 @app.get("/prompts/{prompt_id}")
-async def get_prompt(prompt_id: str):
+async def get_prompt(
+    prompt_id: str, optimizer: PromptOptimizer = Depends(get_optimizer)
+):
     result = optimizer.get_prompt(prompt_id)
     return result.model_dump()
 
 @app.post("/prompts/{prompt_id}/use")
-async def record_prompt_use(prompt_id: str, formatted_text: str):
+async def record_prompt_use(
+    prompt_id: str,
+    formatted_text: str,
+    optimizer: PromptOptimizer = Depends(get_optimizer),
+):
     result = optimizer.record_prompt_use(prompt_id, formatted_text)
     return result.model_dump()
 
 @app.post("/responses/{prompt_instance_id}")
-async def record_response(prompt_instance_id: str, content: str):
+async def record_response(
+    prompt_instance_id: str,
+    content: str,
+    optimizer: PromptOptimizer = Depends(get_optimizer),
+):
     result = optimizer.record_response(prompt_instance_id, content)
     return result.model_dump()
 
 @app.post("/feedback/{response_id}")
-async def record_feedback(response_id: str, score: float):
+async def record_feedback(
+    response_id: str,
+    score: float,
+    optimizer: PromptOptimizer = Depends(get_optimizer),
+):
     result = optimizer.record_feedback(response_id, score)
     return result.model_dump()
 
 @app.post("/optimize/{prompt_id}")
-async def optimize_prompt(prompt_id: str, force: bool = False):
+async def optimize_prompt(
+    prompt_id: str,
+    force: bool = False,
+    optimizer: PromptOptimizer = Depends(get_optimizer),
+):
     result = optimizer.optimize_prompt(prompt_id, force)
     return result.model_dump()
 
 @app.get("/optimization/{prompt_id}")
-async def optimization_stats(prompt_id: str):
+async def optimization_stats(
+    prompt_id: str, optimizer: PromptOptimizer = Depends(get_optimizer)
+):
     result = optimizer.get_optimization_stats(prompt_id)
     return result.model_dump()
 
 @app.get("/config")
-async def get_config():
+async def get_config(optimizer: PromptOptimizer = Depends(get_optimizer)):
     result = optimizer.get_config_info()
     return result.model_dump()

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -7,14 +7,14 @@ from prompt_optimizer.api import PromptOptimizer
 
 @pytest.fixture
 def client(tmp_path):
-    # Replace the global optimizer with one using a temp directory
-    original_optimizer = main.optimizer
-    main.optimizer = PromptOptimizer(
+    """Create a TestClient with a temporary optimizer."""
+    optimizer = PromptOptimizer(
         storage_dir=str(tmp_path), optimization_threshold=2
     )
+    main.app.dependency_overrides[main.get_optimizer] = lambda: optimizer
     client = TestClient(main.app)
     yield client
-    main.optimizer = original_optimizer
+    main.app.dependency_overrides.clear()
 
 
 def test_fastapi_workflow(client):


### PR DESCRIPTION
## Summary
- switch FastAPI routes to use dependency injected `PromptOptimizer`
- expose `get_optimizer` dependency for overrides in tests
- adjust FastAPI test to override the optimizer instance

## Testing
- `pytest tests/test_fastapi_app.py::test_fastapi_workflow -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684abf5b74d48325a19bffcb2722d778